### PR TITLE
Fix: store max_kl_run_number as integer in period report template

### DIFF
--- a/TPCQCVis/reports/TPC_AQC_Template_Period.ipynb
+++ b/TPCQCVis/reports/TPC_AQC_Template_Period.ipynb
@@ -286,7 +286,7 @@
     "            hOutlier.GetXaxis().SetBinLabel(i + 1, runList[i])\n",
     "        if kl_divergence_value > max_kl_divergence:  # Change this condition\n",
     "            max_kl_divergence = kl_divergence_value\n",
-    "            max_kl_run_number = runList[i]  # Store the corresponding run number\n",
+    "            max_kl_run_number = int(runList[i])  # Store the corresponding run number as an integer (convert from string)\n",
     "    \n",
     "    # Outlier: the biggest kl value is the most divergent distribution\n",
     "    if max_kl_run_number > -1:\n",


### PR DESCRIPTION
### Summary

This PR addresses a bug in the outlier detection logic within the period report template `TPC_AQC_Template_Period.ipynb`. Previously, the `max_kl_run_number` variable was stored as a string, which could lead to potential type-related issues in downstream processing.

### Changes Made

- Modified the max_kl_run_number assignment in the outlier detection logic:
`max_kl_run_number = int(runList[i])  # Store the corresponding run number as an integer (convert from string)`

- Ensured that max_kl_run_number is stored as an integer, which aligns with the expected usage elsewhere in the code.